### PR TITLE
corrected heading for SPI in README.rst

### DIFF
--- a/library/README.rst
+++ b/library/README.rst
@@ -130,7 +130,7 @@ When using PCM you cannot use digital audio devices which use I2S since
 I2S uses the PCM hardware, but you can use analog audio.
 
 SPI
-~~
+~~~
 
 When using SPI the ledstring is the only device which can be connected
 to the SPI bus. Both digital (I2S/PCM) and analog (PWM) audio can be


### PR DESCRIPTION
the SPI heading was missing a ~, which read to it not showing as heading. This was corrected.